### PR TITLE
Fix `--seed` flag on `neondb`

### DIFF
--- a/.changeset/cold-dryers-hug.md
+++ b/.changeset/cold-dryers-hug.md
@@ -1,0 +1,7 @@
+---
+"neondb": patch
+---
+
+Fix `--seed` CLI flag
+
+A bug was causing the `-s` flag to be ignored and the `--seed` to throw an exception (because the CLI expected `--sql` instead).

--- a/packages/neondb/mock.sql
+++ b/packages/neondb/mock.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    username VARCHAR(50) NOT NULL UNIQUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO users (username) VALUES
+    ('John Lennon'),
+    ('Paul McCartney'), 
+    ('George Harrison'),
+    ('Ringo Starr'),
+    ('Stuart Sutcliffe'),
+    ('Pete Best'),
+    ('George Martin');

--- a/packages/neondb/src/cli.ts
+++ b/packages/neondb/src/cli.ts
@@ -13,7 +13,7 @@ async function main() {
 	const {
 		env: flagEnvPath,
 		key: flagEnvKey,
-		sql: flagSeedPath,
+		seed: flagSeedPath,
 		yes: shouldUseDefaults,
 	} = getArgs();
 
@@ -109,11 +109,17 @@ async function main() {
 			if (!userInput.seed?.path) {
 				userInput.seed = DEFAULTS.seed;
 			}
+		} else {
+			userInput.seed = {
+				type: "sql-script",
+				path: flagSeedPath,
+			};
 		}
 
 		prepEnv(userInput.dotEnvPath, userInput.dotEnvKey);
 
 		s.start(messages.generating);
+
 		await instantNeon({
 			dotEnvFile: userInput.dotEnvPath,
 			dotEnvKey: userInput.dotEnvKey,

--- a/packages/neondb/src/lib/utils/args.ts
+++ b/packages/neondb/src/lib/utils/args.ts
@@ -23,7 +23,7 @@ export function getArgs() {
 				type: "string",
 				short: "k",
 			},
-			sql: {
+			seed: {
 				type: "string",
 				short: "s",
 			},
@@ -44,7 +44,7 @@ Options:
   -k, --key       Key for the database connection string (default: "${
 		DEFAULTS.dotEnvKey
   }")
-  -s, --sql      Path to the seed (.sql) file (default: "${
+  -s, --seed      Path to the seed (.sql) file (default: "${
 		DEFAULTS.seed?.path || "none"
   }")
   -h, --help      Show this help message


### PR DESCRIPTION
Fix `--seed` CLI flag

A bug was causing the `-s` flag to be ignored and the `--seed` to throw an exception (because the CLI expected `--sql` instead).

