### PR TITLE
Unlock non-interactive flows!

### DIFF
--- a/.changeset/solid-bananas-tell.md
+++ b/.changeset/solid-bananas-tell.md
@@ -1,0 +1,9 @@
+---
+"neondb": minor
+"@neondatabase/vite-plugin-postgres": minor
+---
+
+No more CAPTCHAs
+
+We have removed Cloudflare Turnstile Bot protection from our system.
+This unlocks a completely non-interactive flow to create new databases in Launchpad 🎉

--- a/packages/neondb/src/lib/instant-neon.ts
+++ b/packages/neondb/src/lib/instant-neon.ts
@@ -31,7 +31,10 @@ export const instantNeon = async ({
 	const claimUrl = new URL(LAUNCHPAD_URLS.CLAIM_DATABASE(dbId));
 	log.step(messages.botCheck(createDbUrl.href));
 
-	const connString = await createClaimableDatabase(dbId, createDbUrl);
+	const connString = await createClaimableDatabase(
+		dbId,
+		`npm:neondb|${referrer}`,
+	);
 	const poolerString = getPoolerString(connString);
 
 	log.step(messages.connectionString(connString));

--- a/packages/neondb/src/lib/utils/urls.ts
+++ b/packages/neondb/src/lib/utils/urls.ts
@@ -1,7 +1,14 @@
+// const HOST = "https://neon.new";
+
+const HOST = "http://localhost:3200";
+
 export const LAUNCHPAD_URLS = {
-	GET_DATABASE_DATA: (dbId: string) =>
-		`https://neon.new/api/v1/database/${dbId}`,
+	GET_DATABASE_DATA: (dbId: string) => `${HOST}/api/v1/database/${dbId}`,
 	CREATE_CLAIMABLE_DATABASE: (dbId: string, referrer?: string) =>
-		`https://neon.new/db?uuid=${dbId}${referrer ? `&ref=${referrer}` : ""}`,
-	CLAIM_DATABASE: (dbId: string) => `https://neon.new/database/${dbId}`,
+		`${HOST}/db?uuid=${dbId}${referrer ? `&ref=${referrer}` : ""}`,
+	CLAIM_DATABASE: (dbId: string) => `${HOST}/database/${dbId}`,
+	CREATE_DATABASE_POST: (dbId: string, referrer?: string) =>
+		`${HOST}/api/v1/database/${dbId}${
+			referrer ? `?referrer=${referrer}` : ""
+		}`,
 };


### PR DESCRIPTION
- **replace turnstile check with a direct `POST` call**

We have removed Cloudflare Turnstile Bot protection from our system.
This unlocks a completely non-interactive flow to create new databases in Launchpad 🎉

